### PR TITLE
dep(typos): update to v1.17.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.19
 
 ENV REVIEWDOG_VERSION=v0.16.0
-ENV TYPOS_VERSION=v1.17.1
+ENV TYPOS_VERSION=v1.17.2
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 


### PR DESCRIPTION
This fixes an issue with `.js` being identified with `typoscript`.

https://github.com/crate-ci/typos/releases/tag/v1.17.2