### PR TITLE
fix: git version breaks docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV TYPOS_VERSION=v1.20.9
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 # hadolint ignore=DL3006
-RUN apk --no-cache add git=2.43.0-r0
+RUN apk --no-cache add git=2.43.4-r0
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 


### PR DESCRIPTION
Build Shemnei/reviewdog-action-typos@v0 fails installing git as the [APK does not exists](https://pkgs.alpinelinux.org/packages?name=git&branch=v3.19&repo=&arch=&maintainer=).

![image](https://github.com/Shemnei/reviewdog-action-typos/assets/100362969/cdc15f48-c082-445d-8b14-8940e87a2818)


Updating to an available version resolves the buld issues